### PR TITLE
Add PTNobel to recipe maintainers

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -77,3 +77,4 @@ extra:
     - bstellato
     - gbanjac
     - h-vetinari
+    - PTNobel


### PR DESCRIPTION
Adds Parth Nobel (GitHub: @PTNobel) to the recipe maintainers so he can help maintain the qdldl-python feedstock.

@PTNobel please comment to confirm you're happy to be added as a maintainer.